### PR TITLE
Use virtual for _diff

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function(schema, opts) {
 
 	// Post-init hook stores original
 	schema.post('init', function() {
-		this._original = this.toObject();
+		this._original = this.toObject({transform: false});
 	});
 
     schema.virtual('_diff').get(function() {
@@ -32,10 +32,10 @@ module.exports = function(schema, opts) {
             this._original = {};
         }
 
-        return jdp.diff(this._original, this.toObject());
+        return jdp.diff(this._original, this.toObject({transform: false}));
     });
 
 	schema.post('save', function() {
-		this._original = this.toObject();
+		this._original = this.toObject({transform: false});
 	});
 };

--- a/index.js
+++ b/index.js
@@ -25,17 +25,14 @@ module.exports = function(schema, opts) {
 		this._original = this.toObject();
 	});
 
-	// Post-validate runs before pre-save
-	schema.pre('save', function(next) {
-		// Check that _original is set
-		if (!this._original) {
-			return next();
-		}
+    schema.virtual('_diff').get(function() {
+        // Check that _original is set
+        if (!this._original) {
+            return undefined;
+        }
 
-		// Perform diff
-		this._diff = jdp.diff(this._original, this.toObject());
-		next();
-	});
+        return jdp.diff(this._original, this.toObject());
+    });
 
 	schema.post('save', function() {
 		this._original = this.toObject();

--- a/index.js
+++ b/index.js
@@ -27,8 +27,9 @@ module.exports = function(schema, opts) {
 
     schema.virtual('_diff').get(function() {
         // Check that _original is set
+        // In case of new Schema(), post init is not called
         if (!this._original) {
-            return undefined;
+            this._original = {};
         }
 
         return jdp.diff(this._original, this.toObject());


### PR DESCRIPTION
This allow:
- to not have conflict with pre save declaration order
- to use diff in a non save context
- avoid calling jdp.diff at each save even if the user don't need it
